### PR TITLE
minor branch validation bug fixed

### DIFF
--- a/FPGA_Implementation/mythcore_test.tlv
+++ b/FPGA_Implementation/mythcore_test.tlv
@@ -42,7 +42,7 @@
       //Fetch
          // Next PC
          $pc[31:0] = (>>1$reset) ? '0 : 
-                     (>>3$taken_br) ? >>3$br_tgt_pc : 
+                     (>>3$valid_taken_br) ? >>3$br_tgt_pc : 
                      (>>3$valid_load) ? >>3$inc_pc : 
                      (>>3$valid_jump && >>3$is_jal) ? >>3$br_tgt_pc :
                      (>>3$valid_jump && >>3$is_jalr) ? >>3$jalr_tgt_pc : >>1$inc_pc;

--- a/codes/Final.tlv
+++ b/codes/Final.tlv
@@ -46,7 +46,7 @@
       //Fetch
          // Next PC
          $pc[31:0] = (>>1$reset) ? '0 : 
-                     (>>3$taken_br) ? >>3$br_tgt_pc : 
+                     (>>3$valid_taken_br) ? >>3$br_tgt_pc : 
                      (>>3$valid_load) ? >>3$inc_pc : 
                      (>>3$valid_jump && >>3$is_jal) ? >>3$br_tgt_pc :
                      (>>3$valid_jump && >>3$is_jalr) ? >>3$jalr_tgt_pc : >>1$inc_pc;


### PR DESCRIPTION
Fixes an issue that prevents the following program to run correctly due to a branch validation bug.

```
//The following code shifts left r17 (1 bit per line) and then when r17 == 10'b100000000
//shifts right until r17 == 10'b0000000001 and starts over.

//Initialization
m4_asm(ADDI, r10, r0, 1)
m4_asm(ADDI, r11, r0, 1000000000)
m4_asm(ADDI, r17, r0, 1)

//Loop
m4_asm(SLLI, r17, r17, 1)
m4_asm(BNE, r17, r11, 1111111111100)
m4_asm(SRLI, r17, r17, 1)
m4_asm(BNE, r17, r10, 1111111111100)

//Cause of the issue
m4_asm(BEQ, r0, r0, 1111111110000)
```